### PR TITLE
fix: trailing commas in functions parameter list (single line)

### DIFF
--- a/base.js
+++ b/base.js
@@ -89,7 +89,7 @@ module.exports = {
       {
         arrays: 'always-multiline',
         exports: 'always-multiline',
-        functions: 'ignore',
+        functions: 'always-multiline',
         imports: 'always-multiline',
         objects: 'always-multiline',
       },


### PR DESCRIPTION
- changed trainling comma rule to always-multiline in function parameter list

closed #34