### PR TITLE
fix: no-undef and no-var rule

### DIFF
--- a/tests/typescript/.eslintrc
+++ b/tests/typescript/.eslintrc
@@ -7,8 +7,5 @@
   "parserOptions": {
       "project": "./tests/typescript/tsconfig.json",
       "sourceType": "module"
-  },
-  "globals": {
-    "MyGlobalType": "readonly"
   }
 }

--- a/tests/typescript/.eslintrc
+++ b/tests/typescript/.eslintrc
@@ -7,5 +7,8 @@
   "parserOptions": {
       "project": "./tests/typescript/tsconfig.json",
       "sourceType": "module"
+  },
+  "globals": {
+    "MyGlobalType": "readonly"
   }
 }

--- a/tests/typescript/index.d.ts
+++ b/tests/typescript/index.d.ts
@@ -1,0 +1,7 @@
+declare var myVariable: string;
+
+type MyGlobalType = {
+  name: string,
+  id: string,
+  type: string,
+};

--- a/tests/typescript/tsconfig.json
+++ b/tests/typescript/tsconfig.json
@@ -5,6 +5,7 @@
       "lib": ["esnext", "DOM"],
       "strict": true,
       "moduleResolution": "node",
-      "esModuleInterop": true
+      "esModuleInterop": true,
+      "typeRoots": ["../typescript", "../../node_modules/@types"]
   }
 }

--- a/tests/typescript/various.ts
+++ b/tests/typescript/various.ts
@@ -18,3 +18,11 @@ function myFunc(): MyType | null {
 }
 
 myFunc();
+
+const myGlobalConst: MyGlobalType = {
+  name: 'foobar',
+  id: 'foo',
+  type: 'bar',
+};
+
+console.log(myGlobalConst);

--- a/typescript.js
+++ b/typescript.js
@@ -361,6 +361,7 @@ module.exports = {
         'quotes': 'off', // covered by @typescript-eslint/quotes
         'semi': 'off', // covered by @typescript-eslint/semi
         'space-before-function-paren': 'off', // covered by @typescript-eslint/space-before-function-paren
+        'no-undef': 'off', // off because variables in d.ts files will be shown as error otherwise
         'no-unused-vars': 'off', // covered by @typescript-eslint/no-unused-vars
         'no-var': 'off', // covered by @typescript-esling/no-var
       },

--- a/typescript.js
+++ b/typescript.js
@@ -363,7 +363,7 @@ module.exports = {
         'space-before-function-paren': 'off', // covered by @typescript-eslint/space-before-function-paren
         'no-undef': 'off', // off because variables in d.ts files will be shown as error otherwise
         'no-unused-vars': 'off', // covered by @typescript-eslint/no-unused-vars
-        'no-var': 'off', // covered by @typescript-esling/no-var
+        'no-var': 'off', // covered by @typescript-eslint/no-var
       },
     },
     {

--- a/typescript.js
+++ b/typescript.js
@@ -361,6 +361,8 @@ module.exports = {
         'quotes': 'off', // covered by @typescript-eslint/quotes
         'semi': 'off', // covered by @typescript-eslint/semi
         'space-before-function-paren': 'off', // covered by @typescript-eslint/space-before-function-paren
+        'no-unused-vars': 'off', // covered by @typescript-eslint/no-unused-vars
+        'no-var': 'off', // covered by @typescript-esling/no-var
       },
     },
     {

--- a/typescript.js
+++ b/typescript.js
@@ -361,9 +361,8 @@ module.exports = {
         'quotes': 'off', // covered by @typescript-eslint/quotes
         'semi': 'off', // covered by @typescript-eslint/semi
         'space-before-function-paren': 'off', // covered by @typescript-eslint/space-before-function-paren
-        'no-undef': 'off', // off because variables in d.ts files will be shown as error otherwise
+        'no-undef': 'off', // off because typescript handles it on its own
         'no-unused-vars': 'off', // covered by @typescript-eslint/no-unused-vars
-        'no-var': 'off', // covered by @typescript-eslint/no-var
       },
     },
     {
@@ -375,6 +374,7 @@ module.exports = {
         // be necessary to import the module so that TypeScript finds the typings that should be extended.
         // This is a better alternative to the triple-slash directive
         'import/no-unassigned-import': 'off',
+        'no-var': 'off',
       },
     },
     {


### PR DESCRIPTION
I didn't turn off the `no-undef` rule in the `.eslintrc`-file. Instead I added the specific variable/type to 
`"globals": {
    "MyGlobalType": "readonly"
  }`
in the `.eslintrc`.

If I turn off `no-undef` and we write something as simple as `const a = b + 1;` and `b` has never been declared before, then typescript says `Cannot find name 'b'. ts(2304)`, which is correct. But if we write the same code in a `.js`-file, there won't be any error-message at all, which is not ideal, right?