### PR TITLE
fix: allowing extra parens for TypeScript too

### DIFF
--- a/tests/typescript/test-components.tsx
+++ b/tests/typescript/test-components.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const MyComponent: React.FC = () => (
+  <div>
+    <h1>My Component</h1>
+  </div>
+);
+
+export default MyComponent;

--- a/tests/typescript/tsconfig.json
+++ b/tests/typescript/tsconfig.json
@@ -6,6 +6,7 @@
       "strict": true,
       "moduleResolution": "node",
       "esModuleInterop": true,
-      "typeRoots": ["../typescript", "../../node_modules/@types"]
+      "typeRoots": ["../typescript", "../../node_modules/@types"],
+      "jsx": "react"
   }
 }

--- a/typescript.js
+++ b/typescript.js
@@ -179,7 +179,15 @@ module.exports = {
           },
         ], // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md
         '@typescript-eslint/no-extra-non-null-assertion': ['warn'], // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md
-        '@typescript-eslint/no-extra-parens': 'warn', // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-parens.md
+        '@typescript-eslint/no-extra-parens': [
+          'off', 'all', { // exceptions come here:
+            'enforceForArrowConditionals': false,
+            'enforceForNewInMemberExpressions': false,
+            'ignoreJSX': 'all',
+            'nestedBinaryExpressions': false,
+            'returnAssign': false,
+          },
+        ], // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-parens.md
         '@typescript-eslint/no-extraneous-class': 'off', // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extraneous-class.md
         '@typescript-eslint/no-floating-promises': [
           'warn',


### PR DESCRIPTION
- I copied the configuration for this rule from base 
- I added a test case to test it out