### PR TITLE
feat: deleted prefer-await-to-then

### DIFF
--- a/base.js
+++ b/base.js
@@ -487,7 +487,7 @@ module.exports = {
     'promise/no-return-in-finally': 'warn', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/no-return-in-finally.md
     'promise/no-return-wrap': 'error', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/no-return-wrap.md
     'promise/param-names': 'error', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/param-names.md
-    // * it's better to use one syntax so the await syntax should be our standard
+    // * it's better to use one syntax so the await syntax should be our standard and in some cases the `then` syntax can be used
     'promise/prefer-await-to-callbacks': 'warn', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-callbacks.md
     // * it's better to use one syntax so the await syntax should be our standard
     'promise/valid-params': 'error', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/valid-params.md

--- a/base.js
+++ b/base.js
@@ -489,7 +489,7 @@ module.exports = {
     'promise/param-names': 'error', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/param-names.md
     // * it's better to use one syntax so the await syntax should be our standard and in some cases the `then` syntax can be used
     'promise/prefer-await-to-callbacks': 'warn', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-callbacks.md
-    // * it's better to use one syntax so the await syntax should be our standard
+    'promise/prefer-await-to-then': 'off', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md
     'promise/valid-params': 'error', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/valid-params.md
     'quote-props': ['error', 'consistent-as-needed'], // https://eslint.org/docs/rules/quote-props
     'quotes': ['error', 'single', { allowTemplateLiterals: true }], // handled by @babel/quotes

--- a/base.js
+++ b/base.js
@@ -490,7 +490,6 @@ module.exports = {
     // * it's better to use one syntax so the await syntax should be our standard
     'promise/prefer-await-to-callbacks': 'warn', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-callbacks.md
     // * it's better to use one syntax so the await syntax should be our standard
-    'promise/prefer-await-to-then': 'warn', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md
     'promise/valid-params': 'error', // https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/valid-params.md
     'quote-props': ['error', 'consistent-as-needed'], // https://eslint.org/docs/rules/quote-props
     'quotes': ['error', 'single', { allowTemplateLiterals: true }], // handled by @babel/quotes


### PR DESCRIPTION
Deleted typescript-prefer-await as it is too opinionated about where to use await.