### PR TITLE
feat: added no-loss-of-precision-rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -302,6 +302,7 @@ module.exports = {
     'no-lone-blocks': 'error', // https://eslint.org/docs/rules/no-lone-blocks
     'no-lonely-if': 'warn', // https://eslint.org/docs/rules/no-lonely-if
     'no-loop-func': 'error', // https://eslint.org/docs/rules/no-loop-func
+    'no-loss-of-precision' : 'warn', //https://eslint.org/docs/rules/no-loss-of-precision
     'no-magic-numbers': [
       'off',
       {


### PR DESCRIPTION
## What was done?
- no loss of precision rule was added

## QA: 
- add this line `const x = 5123000000000000000000000000001` to `spacing.js` and run `npm run test:base`, a warning should appear