### PR TITLE
fix: enum already declared in upper scope in ts

### DIFF
--- a/tests/base/base.test.js
+++ b/tests/base/base.test.js
@@ -14,7 +14,7 @@ describe('base config', () => {
     expect(result.warningCount).toBe(0);
     expect(result.messages.some((message) => message.ruleId === 'array-func/prefer-array-from')).toBe(false);
   });
-  
+
   it('should allow up to 500 lines in a js-file', async () => {
     // arrange
     const linter = new ESLint();
@@ -31,7 +31,7 @@ describe('base config', () => {
     expect(failingResult.warningCount).toBe(1);
     expect(failingResult.messages.some((message) => message.ruleId === 'max-lines')).toBe(true);
   });
-  
+
   it('should allow more then 3 params passed to function', async () => {
     // arrange
     const linter = new ESLint();
@@ -43,5 +43,16 @@ describe('base config', () => {
     // assert
     expect(result.warningCount).toBe(0);
   });
+  it('should produce a warning for shadowed variables', async () => {
+    // arrange
+    const linter = new ESLint();
+    const fileName = 'tests/base/no-shadow.js';
 
+    // act
+    const [result] = await linter.lintFiles([fileName]);
+
+    // assert
+    expect(result.warningCount).toBe(1);
+    expect(result.messages.some((message) => message.ruleId === 'no-shadow')).toBe(true);
+  });
 });

--- a/tests/base/no-shadow.js
+++ b/tests/base/no-shadow.js
@@ -1,0 +1,9 @@
+
+const x = 1;
+
+function y(z) {
+  const x = 2;
+  return x - z;
+}
+
+y(x);

--- a/tests/typescript/enum.ts
+++ b/tests/typescript/enum.ts
@@ -1,0 +1,16 @@
+enum Fruits {
+  APPLE,
+  BANANA,
+  PEACH
+}
+
+function getEmoji(fruit: Fruits) {
+  switch (fruit) {
+    case Fruits.APPLE: return '🍎';
+    case Fruits.BANANA: return '🍌';
+    case Fruits.PEACH: return '🍑';
+    default: throw new Error('Unknow fruit!');
+  }
+}
+
+getEmoji(Fruits.APPLE);

--- a/tests/typescript/typescript.test.ts
+++ b/tests/typescript/typescript.test.ts
@@ -41,4 +41,18 @@ describe('typescript config', () => {
     expect(result.errorCount).toBe(1);
     expect(result.messages.some((message) => message.ruleId === '@typescript-eslint/no-non-null-assertion')).toBe(true);
   });
+
+  it('should not produce a warning "no-shadow" when using an enum in TypeScript', async () => {
+    // arrange
+    const linter = new ESLint();
+    const fileName = 'tests/typescript/enum.ts';
+
+    // act
+    const [result] = await linter.lintFiles([fileName]);
+
+    // assert
+    expect(result.warningCount).toBe(0);
+    expect(result.errorCount).toBe(0);
+    expect(result.messages.some((message) => message.ruleId === 'no-shadow')).toBe(false);
+  });
 });

--- a/typescript.js
+++ b/typescript.js
@@ -363,6 +363,7 @@ module.exports = {
         'no-loop-func': 'off', // covered by @typescript-eslint/no-loop-func
         'no-loss-of-precision': 'off', // covered by @typescript-eslint/no-loss-of-precision
         'no-redeclare': 'off', // covered by @typescript-eslint/no-redeclare
+        'no-shadow': 'off', // covered by  @typescript-eslint/no-shadow
         'no-undef': 'off', // off because typescript handles it on its own
         'no-unused-vars': 'off', // covered by @typescript-eslint/no-unused-vars
         'no-useless-constructor': 'off', // covered by @typescript-eslint/no-useless-constructor


### PR DESCRIPTION
- disabled `no-shadow` rule in the typescript context
- added tests

closes #116 
